### PR TITLE
Update Set-D9Creds

### DIFF
--- a/PsPCOS.psm1
+++ b/PsPCOS.psm1
@@ -1,4 +1,4 @@
-<#
+ <#
 .Synopsis
    Creates a global credential object ($D9Creds) with the user's Service ID credentials.
 .DESCRIPTION
@@ -15,7 +15,7 @@ function Set-D9Creds
     [Alias('D9')]
     Param
     (
-        # Username
+        # Param1 help description
         [Parameter(Mandatory=$false,
                    ValueFromPipelineByPropertyName=$true,
                    Position=0)]
@@ -32,19 +32,22 @@ function Set-D9Creds
     Process
     {
         Do {
-            $Global:D9Creds = Get-Credential -Message 'Enter Service ID credentials.'
+            $Global:D9Creds = Get-Credential -Message 'Enter Service ID credentials.' -UserName $Username
 
-            $Valid = $PrincipalContext.ValidateCredentials($D9Creds.UserName,$D9Creds.GetNetworkCredential().Password)
+            If ($D9Creds)
+            {
+                $Valid = $PrincipalContext.ValidateCredentials($D9Creds.UserName,$D9Creds.GetNetworkCredential().Password)
 
-            If (!$Valid) {
-                Write-Host "Authetication for $($D9Creds.Username) failed." -ForegroundColor Red
+                If (!$Valid) {
+                    Write-Host "Authetication for $($D9Creds.Username) failed." -ForegroundColor Red
+                }
             }
 
-        } While (!$Valid)
+        } While (!$Valid -and $D9Creds -ne $null)
 
     }
     End
     {
         Write-Host "Credentials for $($D9Creds.UserName) successfully set to `$D9Creds object." -ForegroundColor Green
     }
-}
+} 


### PR DESCRIPTION
Updated Set-D9Creds cmdlet to fix "Username" parameter, and to allow for the "Cancel" button on the credentials prompt to exit the "Do" loop.